### PR TITLE
Add ability for SensorConnectorInterface to request that SensorConnector application quit

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,128 @@
+// Type definitions for SensorConnectorInterface 0.1.2
+// Project: https://github.com/concord-consortium/sensor-connector-interface
+// Definitions by: The Concord Consortium <https://concord.org>
+
+/*~ Note that ES6 modules cannot directly export class objects.
+ *~ This file should be imported using the CommonJS-style:
+ *~   import x = require('someLibrary');
+ *~
+ *~ Refer to the documentation to understand common
+ *~ workarounds for this limitation of ES6 modules.
+ */
+
+/*~ This declaration specifies that the class constructor function
+ *~ is the exported object from the file
+ *~ You may need to set the "allowSyntheticDefaultImports" property in tsconfig.json
+ */
+export = SensorConnectorInterface;
+
+declare interface ISensorConnectorState {
+    // private implementation details
+}
+
+declare interface ISensorDefinition {
+    sensorName:string|null;
+    measurementName:string;
+    measurementType:string;
+    tareable:boolean;
+    minReading:number;
+    maxReading:number;
+}
+  
+declare interface ISensorConnectorDataset {
+    id:string;
+    columns:ISensorConfigColumnInfo[];
+}
+  
+declare interface ISensorConfigColumnInfo {
+    id:string;
+    setID:string;
+    position:number;
+    name:string;
+    units:string;
+    liveValue:string;
+    liveValueTimeStamp:Date;
+    valueCount:number;
+    valuesTimeStamp:Date;
+    data?:number[];
+}
+type SensorConfigColumnInfo = ISensorConfigColumnInfo;
+  
+declare interface ISensorConfigSet {
+    name:string;
+    colIDs:number[];
+}
+  
+declare interface ISensorConfig {
+    collection:{ canControl:boolean; isCollecting:boolean; };
+    columnListTimeStamp:Date;
+    columns:{ [key:string]: ISensorConfigColumnInfo; };
+    currentInterface:string;
+    currentState:string;
+    os:{ name:string; version:string; };
+    requestTimeStamp:Date;
+    server:{ arch:string; version:string; };
+    sessionDesc:string;
+    sessionID:string;
+    sets:{ [key:string]: ISensorConfigSet; };
+    setID?:string;
+}
+  
+declare interface IMachinaAction {
+    inputType:string;
+    delegated:boolean;
+    ticket:any;
+}
+  
+declare interface IStatusReceivedTuple
+          extends Array<IMachinaAction|ISensorConfig>
+                    {0:IMachinaAction; 1:ISensorConfig;}
+
+declare interface IColumnDataTuple
+          extends Array<IMachinaAction|string|number[]|Date>
+                    {0:IMachinaAction; 1:string; 2:number[]; 3:Date;}
+
+/*~ Write your module's methods and properties in this class */
+declare class SensorConnectorInterface {
+    constructor();
+
+    stateMachine: ISensorConnectorState;
+
+    startPolling(addresses: string | string[], clientId?: string, clientName?: string) : void;
+    stopPolling(): void;
+
+    requestStart(): Promise<string>;
+    requestStop(): Promise<string>;
+
+    requestExit(): Promise<string>;
+    requestLaunch(): boolean;
+
+    on(event: string, handler: Function): void;
+    off(): void;
+
+    clientId: string;
+    clientName: string;
+
+    readonly hasAttachedInterface: boolean;
+
+    readonly datasets: ISensorConnectorDataset[];
+    readonly currentActionArgs: IStatusReceivedTuple;
+
+    readonly isConnected: boolean;
+    readonly isCollecting: boolean;
+    readonly inControl: boolean;
+    readonly canControl: boolean;
+    readonly launchTimedOut: boolean;
+}
+
+/*~ If you want to expose types from your module as well, you can
+ *~ place them in this block.
+ */
+declare namespace SensorConnectorInterface {
+    export type SensorDefinition = ISensorDefinition;
+    export type SensorConnectorDataset = ISensorConnectorDataset
+    export type SensorConfigColumnInfo = ISensorConfigColumnInfo
+    export type SensorConfig = ISensorConfig
+    export type StatusReceivedTuple = IStatusReceivedTuple
+    export type ColumnDataTuple = IColumnDataTuple
+}

--- a/index.html
+++ b/index.html
@@ -41,20 +41,30 @@
         }
         sensor = new sensorConnectorInterface();
         
-        $('#connect').on('click', function() {
+        function connect() {
             $('#control-status').html('Remote control is enabled. To collect data, press start/stop on this page.');
             var ip = $('input[name=ip]').val();
-            sensor.startPolling(sensorIP);
             sensor.on('*', function() {
                 var args = Array.prototype.slice.call(arguments, 0);
                 $('#events').prepend('<p>' + this.event + '(' + args.join(',') + ')</p>');
             });
             sensor.on('data', dataHandler);
+            sensor.startPolling(sensorIP);
+        }
+
+        function disconnect() {
+            sensor.stopPolling();
+            // remove all listeners
+            sensor.off();
+            $('#control-status').html('Click Connect.');
+        }
+
+        $('#connect').on('click', function() {
+            connect();
         });
 
         $('#disconnect').on('click', function() {
-            sensor.stopPolling();
-            $('#control-status').html('Click Connect.');
+            disconnect();
         });
 
         $('#start').on('click', function() {
@@ -63,6 +73,11 @@
 
         $('#stop').on('click', function() {
             sensor.requestStop();
+        });
+
+        $('#exit').on('click', function() {
+            disconnect();
+            sensor.requestExit();
         });
 
         sensor.on('controlDisabled', function() {
@@ -157,6 +172,7 @@
 
 <button id="start">Start</button>
 <button id="stop">Stop</button>
+<button id="exit">Exit</button>
 <span id="control-status">Click Connect to start.</span>
 
 <div class="flexBox">

--- a/package-lock.json
+++ b/package-lock.json
@@ -177,7 +177,7 @@
         "htmlescape": "1.1.1",
         "https-browserify": "1.0.0",
         "inherits": "2.0.3",
-        "insert-module-globals": "7.0.5",
+        "insert-module-globals": "7.0.6",
         "labeled-stream-splicer": "2.0.1",
         "mkdirp": "0.5.1",
         "module-deps": "6.0.2",
@@ -189,7 +189,7 @@
         "querystring-es3": "0.2.1",
         "read-only-stream": "2.0.0",
         "readable-stream": "2.3.6",
-        "resolve": "1.6.0",
+        "resolve": "1.7.0",
         "shasum": "1.0.2",
         "shell-quote": "1.6.1",
         "stream-browserify": "2.0.1",
@@ -659,9 +659,9 @@
       }
     },
     "insert-module-globals": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.5.tgz",
-      "integrity": "sha512-wgRtrCpMm0ruH2hgLUIx+9YfJsgJQmU1KkPUzTuatW9dbH19yPRqAQhFX1HJU6zbmg2IMmt80BgSE5MWuksw3Q==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.6.tgz",
+      "integrity": "sha512-R3sidKJr3SsggqQQ5cEwQb3pWG8RNx0UnpyeiOSR6jorRIeAOzH2gkTWnNdMnyRiVbjrG047K7UCtlMkQ1Mo9w==",
       "dev": true,
       "requires": {
         "JSONStream": "1.3.2",
@@ -669,6 +669,7 @@
         "concat-stream": "1.6.2",
         "is-buffer": "1.1.6",
         "lexical-scope": "1.2.0",
+        "path-is-absolute": "1.0.1",
         "process": "0.11.10",
         "through2": "2.0.3",
         "xtend": "4.0.1"
@@ -853,7 +854,7 @@
         "inherits": "2.0.3",
         "parents": "1.0.1",
         "readable-stream": "2.3.6",
-        "resolve": "1.6.0",
+        "resolve": "1.7.0",
         "stream-combiner2": "1.1.1",
         "subarg": "1.0.0",
         "through2": "2.0.3",
@@ -1038,9 +1039,9 @@
       }
     },
     "resolve": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
-      "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
+      "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "JavaScript interface to the Sensor Connector",
   "license": "MIT",
   "main": "dist/sensor-connector-interface.js",
+  "types": "index.d.ts",
   "files": [
     "dist"
   ],
@@ -18,7 +19,9 @@
     "browserify": "^16.1.1"
   },
   "scripts": {
-    "build": "mkdir -p dist && browserify main.js --standalone sensor-connector-interface > dist/sensor-connector-interface.js",
+    "build": "mkdir -p dist && npm run bundle",
+    "bundle": "browserify main.js --standalone sensor-connector-interface > dist/sensor-connector-interface.js",
+    "clean": "rm -rf dist",
     "start": "open index.html",
     "test": "echo \"Error: no test specified\" && exit 1"
   }

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "@concord-consortium/sensor-connector-interface",
   "version": "0.1.2",
   "author": "The Concord Consortium",
-  "description": "Javascript interface to the Sensor Connector",
+  "description": "JavaScript interface to the Sensor Connector",
   "license": "MIT",
   "main": "dist/sensor-connector-interface.js",
-  "files": [ "dist" ],
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "es6-promise": "^4.2.4",
     "eventemitter2": "^5.0.1",


### PR DESCRIPTION
- add Exit button to test harness
- better handling when client attempts to send command before connection established
- make sure iframe used to connect to SensorConnector stays hidden
- add ability to remove all listeners with SensorConnectorInterface.off()
  - helps prevent memory leaks

Note: it's not clear how best to work quitting the SensorConnector application into the overall behavior of the SensorConnectorInterface/SensorInteractive, but this gives us the ability to try to determine how best to do so.